### PR TITLE
Update envio to v2.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "envio": "2.13.0",
+    "envio": "2.21.0",
     "sqlite3": "^5.1.7"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 2.13.0
-        version: 2.13.0(typescript@5.2.2)
+        specifier: 2.21.0
+        version: 2.21.0(typescript@5.2.2)
       sqlite3:
         specifier: ^5.1.7
         version: 5.1.7
@@ -648,27 +648,27 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envio-darwin-arm64@2.13.0:
+  envio-darwin-arm64@2.21.0:
     resolution: {integrity: sha512-r/Yo5ttxWsNje5xhjfm/CS5JGXreAGuve6fzsrsf/TSYUpAQ5mgUWdTnKh8ttFXkxXOPJJNTRQWvqKO/wZHC1g==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@2.13.0:
+  envio-darwin-x64@2.21.0:
     resolution: {integrity: sha512-vsvImvMPI9HTYSSCee4RFn1gv7Z+WFAFsTBwAKsEO4flSFm34i+67kLjduPr6RCUAJefIRx9feTWk6CnOcdZug==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@2.13.0:
+  envio-linux-arm64@2.21.0:
     resolution: {integrity: sha512-ZgI7SRH8gIAm/0FtSn7sE+7adMfdra+LbSbVfO5RQGXIZEScdcVAfU11Y8A6hug/c7Xu77AWcHnJZXZBLBV1Qw==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@2.13.0:
+  envio-linux-x64@2.21.0:
     resolution: {integrity: sha512-5YdzcF/DfyuH+ranHaZW+ZX97bjX+sidVrTI9Z7XhZ3LdQKddonmG+LlNk6GKLWGOofMTBLXM3hkLeaHVbYELQ==}
     cpu: [x64]
     os: [linux]
 
-  envio@2.13.0:
+  envio@2.21.0:
     resolution: {integrity: sha512-nyXtcCGBrbSJY0yCC2Wrlif2Kg9b9eKyX7HpWOthqrDKpIzDc2xdLJV6HL8XF0eU4NKuD0KAs6P6qUl5GJ7tGw==}
     hasBin: true
 
@@ -2318,29 +2318,29 @@ snapshots:
   env-paths@2.2.1:
     optional: true
 
-  envio-darwin-arm64@2.13.0:
+  envio-darwin-arm64@2.21.0:
     optional: true
 
-  envio-darwin-x64@2.13.0:
+  envio-darwin-x64@2.21.0:
     optional: true
 
-  envio-linux-arm64@2.13.0:
+  envio-linux-arm64@2.21.0:
     optional: true
 
-  envio-linux-x64@2.13.0:
+  envio-linux-x64@2.21.0:
     optional: true
 
-  envio@2.13.0(typescript@5.2.2):
+  envio@2.21.0(typescript@5.2.2):
     dependencies:
       '@envio-dev/hypersync-client': 0.6.3
       rescript: 11.1.3
       rescript-schema: 9.1.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.2.2)
     optionalDependencies:
-      envio-darwin-arm64: 2.13.0
-      envio-darwin-x64: 2.13.0
-      envio-linux-arm64: 2.13.0
-      envio-linux-x64: 2.13.0
+      envio-darwin-arm64: 2.21.0
+      envio-darwin-x64: 2.21.0
+      envio-linux-arm64: 2.21.0
+      envio-linux-x64: 2.21.0
     transitivePeerDependencies:
       - bufferutil
       - typescript


### PR DESCRIPTION
## Summary
- bump `envio` from `2.13.0` to `2.21.0`

## Testing
- `pnpm test` *(fails: ts-mocha not found)*